### PR TITLE
note management now works for all 3 tabs

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/JournalManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/JournalManager.cs
@@ -10,11 +10,13 @@ namespace TabloidCLI.UserInterfaceManagers
     {
         private IUserInterfaceManager _parentUI;
         private JournalRepository _journalRepository;
+        private string _connectionString;
 
         public JournalManager(IUserInterfaceManager parentUI, string connectionString)
         {
             _parentUI = parentUI;
             _journalRepository = new JournalRepository(connectionString);
+            _connectionString = connectionString;
         }
 
 
@@ -45,8 +47,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     DeleteJournalEntry();
                     return this;
                 case "5":
-                    throw new NotImplementedException();
-                    break;
+                    return new NoteManager(this, _connectionString);
                 case "0":
                     return _parentUI;
                 default:

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -13,6 +13,7 @@ namespace TabloidCLI.UserInterfaceManagers
         private PostRepository _postRepository;
         private AuthorRepository _authorRepository;
         private BlogRepository _blogRepository;
+        private string _connectionString;
 
         public PostManager(IUserInterfaceManager parentUI, string connectionString)
         {
@@ -20,6 +21,7 @@ namespace TabloidCLI.UserInterfaceManagers
             _postRepository = new PostRepository(connectionString);
             _authorRepository = new AuthorRepository(connectionString);
             _blogRepository = new BlogRepository(connectionString);
+            _connectionString = connectionString;
         }
 
 
@@ -50,8 +52,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     Remove();
                     return this;
                 case "5":
-                    throw new NotImplementedException();
-                    break;
+                    return new NoteManager(this, _connectionString);
                 case "0":
                     return _parentUI;
                 default:


### PR DESCRIPTION
# Description
Added functionality to the post and journal manager section so that when you enter note management in each of those sections, the menu displays with options.
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
Run the program and select either journal management or post management. In either of those menus, select note management so that the menu displays with its options.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works